### PR TITLE
refactor: report error reason as map

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,3 +18,4 @@ _build
 rebar3.crashdump
 *.html
 TAGS
+doc/


### PR DESCRIPTION
prior to this change, the the error messages are formated using
io_lib which is not always helpful when errors are not always
formatted as strings in logs