### PR TITLE
Avoid using erl_scan for primitive types

### DIFF
--- a/test/from_string_tests.erl
+++ b/test/from_string_tests.erl
@@ -15,15 +15,34 @@ from_string_test() ->
   ?assertMatch({ok, "foo"}, typerefl:from_string(string(), "foo")),
   ?assertMatch({ok, <<"foo">>}, typerefl:from_string(binary(), "foo")),
   ?assertMatch({ok, <<0, 12, 3>>}, typerefl:from_string(binary(), [0, 12, 3])),
+
   ?assertMatch({ok, true},  typerefl:from_string(boolean(), "true")),
   ?assertMatch({ok, false}, typerefl:from_string(boolean(), "false")),
-  ?assertMatch({ok, "1"}, typerefl:from_string(string(), "1")),
-  ?assertMatch({ok, '1'}, typerefl:from_string(atom(), "1")),
-  ?assertMatch({ok, 1}, typerefl:from_string(integer(), "1")),
-  ?assertMatch({ok, 1.1}, typerefl:from_string(float(), "1.1")),
-  ?assertMatch({ok, {foo, "bar", []}}, typerefl:from_string(term(), "{foo, \"bar\", []}")),
+  ?assertMatch({ok, true},  typerefl:from_string(boolean(), " true ")),
+  ?assertMatch({ok, false}, typerefl:from_string(boolean(), " false ")),
   ?assertMatch({error, _}, typerefl:from_string(boolean(), "}")),
   ?assertMatch({error, _}, typerefl:from_string(boolean(), ",")),
+
+  ?assertMatch({ok, "1"}, typerefl:from_string(string(), "1")),
+  ?assertMatch({ok, '1'}, typerefl:from_string(atom(), "1")),
+
+  ?assertMatch({ok, 1}, typerefl:from_string(integer(), "1")),
+  ?assertMatch({ok, 1}, typerefl:from_string(integer(), " 1 ")),
+  ?assertMatch({error, _}, typerefl:from_string(integer(), " abc ")),
+
+  ?assertMatch({ok, 1.1}, typerefl:from_string(float(), "1.1")),
+  ?assertMatch({ok, 1.1}, typerefl:from_string(float(), " 1.1 ")),
+  ?assertMatch({error, _}, typerefl:from_string(float(), " 1 ")),
+
+  ?assertMatch({ok, 1.1}, typerefl:from_string(number(), "1.1")),
+  ?assertMatch({ok, 1.1}, typerefl:from_string(number(), " 1.1 ")),
+  ?assertMatch({ok, 1}, typerefl:from_string(number(), " 1 ")),
+
+  ?assertMatch({error, _}, typerefl:from_string(pid(), "<0.123.0>")),
+  ?assertMatch({error, _}, typerefl:from_string(port(), "#Port<0.5>")),
+  ?assertMatch({error, _}, typerefl:from_string(number(), "#Ref<0.4195819181.3441426434.261872>")),
+
+  ?assertMatch({ok, {foo, "bar", []}}, typerefl:from_string(term(), "{foo, \"bar\", []}")),
   ?assertMatch({ok, foo}, typerefl:from_string(foo, "foo")),
   ?assertMatch({error, _}, typerefl:from_string(foo, "bar")),
   ?assertMatch({ok, ''}, typerefl:from_string('', "")),


### PR DESCRIPTION
Here we allow spaces around primitives because they are allowed currently.

I.e. I think we need to have
```erlang
{ok, 1.1} = typerefl:from_string(number(), "  1.1  ")
```

Because  values like `"  1.1  "` are fine for validations, and some strange users can have them in their configs.
```
Eshell V10.7  (abort with ^G)
1> Sc = #{roots => [{<<"key">>, hoconsc:mk(typerefl:float())}]}.  
#{roots =>
      [{<<"key">>,
        #{type =>
              {'$type_refl',#{check => fun erlang:is_float/1,name => "float()"}}}}]}
2> ConfMap = #{<<"key">> => "  1.1  "}.
#{<<"key">> => "  1.1  "}
3> hocon_schema:map(Sc, ConfMap, all, #{format => map}).
{[],#{<<"key">> => 1.1}}
```

Also, I have added constant unsuccessful parsing for pids, refs and ports because their parsing seems to have no sense and Erlang docs advise to parse them only for debugging purposes (https://erlang.org/doc/man/erlang.html#list_to_pid-1). 
But I am not sure if we need this. 