### PR TITLE
feat: flatten print result

### DIFF
--- a/src/typerefl.app.src
+++ b/src/typerefl.app.src
@@ -1,6 +1,6 @@
 {application,typerefl,
              [{description,"Runtime type-checker for Erlang"},
-              {vsn,"0.1.1"},
+              {vsn,"0.9.1"},
               {registered,[]},
               {applications,[kernel,stdlib]},
               {env,[]},

--- a/src/typerefl.erl
+++ b/src/typerefl.erl
@@ -145,8 +145,9 @@ print(Type) ->
     _ ->
       Defn = [lists:flatten(io_lib:format("~s :: ~s", [K, V]))
               || {K, V} <- Defn1],
-      io_lib:format( "~s when~n  ~s."
-                   , [name(Type), string:join(Defn, ",\n  ")])
+      lists:flatten(
+                   io_lib:format( "~s when~n  ~s."
+                                , [name(Type), string:join(Defn, ",\n  ")]))
   end.
 
 


### PR DESCRIPTION
we catch some error which is different to undestand.  such as:
```json
{ "expected": [ "emqx_limiter_schema:burst_rate()", 32, 119, 104, 101, 110, 10, 32, 32, 
"emqx_limiter_schema:burst_rate() :: float() | 0", 46 ], "got": "d0/0s", 
"reason": "typerefl_typecheck", "typerefl_path": { "emqx_limiter_schema:burst_rate()": "d0/0s" } }, 
"value": "d0/0s" }
```
flatten this for a better look.
```json
 { "expected": "emqx_limiter_schema:burst_rate() when\n emqx_limiter_schema:burst_rate() :: float() | 0.", 
"got": "d0/0s", "reason": "typerefl_typecheck", 
"typerefl_path": { "emqx_limiter_schema:burst_rate()": "d0/0s" } }, "value": "d0/0s" }
```