### PR TITLE
fix: unmask `from_string` converter exceptions

### DIFF
--- a/src/typerefl.erl
+++ b/src/typerefl.erl
@@ -185,11 +185,7 @@ from_string({?type_refl, Type}, Str) ->
                 , Type
                 , fun string_to_term/1
                 ),
-  try Fun(Str) of
-    Val -> Val
-  catch
-    _:_ -> {error, "Unable to parse"}
-  end;
+  Fun(Str);
 from_string(Atom, Str) when is_atom(Atom) -> %% Why would anyone want to parse a known atom? Weird, but ok
   case atom_to_list(Atom) of
     Str ->


### PR DESCRIPTION
This PR reverts small piece of the changes introduced in e0f660696d66b31e41d55599df8e28da9e958bcd.

As demonstrated by testcases in https://github.com/emqx/hocon/blob/0.43.4/test/hocon_schema_builtin_tests.erl, `hocon_tconf` expects `typerefl` not to catch and mask exceptions originating from respective `from_string` converter for a type.